### PR TITLE
Remove unneeded external reference to HAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-# Object file
-*.o
+obj
 
-# Ada Library Information
-*.ali

--- a/src/virtapu.ads
+++ b/src/virtapu.ads
@@ -1,4 +1,3 @@
-with HAL;
 with Interfaces;
 
 --  Virtual Audio Processing Unit
@@ -21,7 +20,7 @@ package VirtAPU is
    type Mode_Kind is (Pulse, Triangle, Noise_1, Noise_2);
    --  Mode of the channel oscillator
 
-   type Tick_Count is new HAL.UInt32;
+   type Tick_Count is new Interfaces.Unsigned_32;
 
    type Volume is range 0 .. 100;
 

--- a/virtapu.gpr
+++ b/virtapu.gpr
@@ -1,5 +1,3 @@
-with "hal.gpr";
-
 project VirtAPU is
 
   for Source_Dirs use ("src");

--- a/virtapu.gpr
+++ b/virtapu.gpr
@@ -6,4 +6,6 @@ project VirtAPU is
 
   for Object_Dir use "obj";
 
+  for Create_Missing_Dirs use "True";
+
 end VirtAPU;


### PR DESCRIPTION
Changes in order of importance:

* Removes the reference to external HAL project.
  The sole reference was in
  ```ada
  type Tick_Count is new HAL.UInt32;
  ```
  which could easily be replaced with
  ```ada
  type Tick_Count is new Interfaces.Unsigned_32;
  ```

* The project file now creates the obj directory if necessary.

* .gitignore has been fixed to ignore the obj directory.